### PR TITLE
Fixing getMatchingOption

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1230,10 +1230,11 @@ export function getMatchingOption(formData, options, rootSchema) {
       // been filled in yet, which will mean that the schema is not valid
       delete augmentedSchema.required;
 
-      if (isValid(augmentedSchema, formData, rootSchema)) {
+      if (formData && isValid(augmentedSchema, formData, rootSchema)) {
         return i;
       }
-    } else if (isValid(option, formData, rootSchema)) {
+      return i;
+    } else if (formData && isValid(option, formData, rootSchema)) {
       return i;
     }
   }


### PR DESCRIPTION
Fixing getMatchingOption in the case of oneOf/anyOf by validating schema only when formData is available

### Reasons for making this change

[Please describe them here]

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
